### PR TITLE
Fix missing order parameter when calling toInvoice function

### DIFF
--- a/app/code/community/Lengow/Connector/Model/Import/Order.php
+++ b/app/code/community/Lengow/Connector/Model/Import/Order.php
@@ -797,7 +797,7 @@ class Lengow_Connector_Model_Import_Order extends Mage_Core_Model_Abstract
             ) {
                 // if order is new -> generate invoice
                 if ($order->getState() === $this->getOrderState(self::STATE_NEW)) {
-                    $this->toInvoice();
+                    $this->toInvoice($order);
                 }
                 if (!empty($trackings)) {
                     $tracking = $trackings[0];


### PR DESCRIPTION
Hello,
`$order` parameter is missing when calling the `toInvoice` function here.