### PR TITLE
Dispatch an event during product export

### DIFF
--- a/app/code/community/Lengow/Connector/Model/Export.php
+++ b/app/code/community/Lengow/Connector/Model/Export.php
@@ -612,6 +612,13 @@ class Lengow_Connector_Model_Export extends Varien_Object
                 : '';
             $datas['child_name'] = $this->_helper->cleanData($product->getName());
             $datas['language'] = Mage::app()->getLocale()->getLocaleCode();
+
+            // Dispatch an event so other modules can update $datas
+            $datasObject = new Varien_Object();
+            $datasObject->setData($datas);
+            Mage::dispatchEvent('lengow_export_products_datas', ['datas' => $datasObject]);
+            $datas = $datasObject->getData();
+
             // get correct feed
             $productDatas = array();
             foreach ($this->_defaultFields as $key => $value) {

--- a/app/code/community/Lengow/Connector/Model/Export.php
+++ b/app/code/community/Lengow/Connector/Model/Export.php
@@ -792,6 +792,13 @@ class Lengow_Connector_Model_Export extends Varien_Object
             }
         }
         $this->_defaultFields = $this->_legacy ? $this->_legacyFields : $this->_newFields;
+
+        $defaultFields = new Varien_Object();
+        $defaultFields->setData($this->_defaultFields);
+
+        Mage::dispatchEvent('lengow_export_products_defaultFields', ['default_fields' => $defaultFields]);
+        
+        $this->_defaultFields = $defaultFields->getData();
     }
 
     /**

--- a/app/code/community/Lengow/Connector/Model/Import/Importorder.php
+++ b/app/code/community/Lengow/Connector/Model/Import/Importorder.php
@@ -1148,6 +1148,14 @@ class Lengow_Connector_Model_Import_Importorder extends Varien_Object
             'store_currency_code' => (string)$this->_orderData->currency->iso_a3,
             'order_currency_code' => (string)$this->_orderData->currency->iso_a3,
         );
+
+        $additionalDatasObject = new Varien_Object();
+        $additionalDatasObject->setData($additionalDatas);
+
+        Mage::dispatchEvent('lengow_import_order_additionalDatas', ['additional_datas' => $additionalDatasObject]);
+
+        $additionalDatas = $additionalDatasObject->getData();
+
         $service = Mage::getModel('sales/service_quote', $quote);
         $service->setOrderData($additionalDatas);
         /** @var Mage_Sales_Model_Order $order */


### PR DESCRIPTION
Hello,

The aim here is to add an event after the generation of the `$datas` values.

Our customers often need to customize theses values and it would avoid us a rewrite.

Example of use in a custom module:

`config.xml`

```xml
[...]
<events>
   <lengow_export_products_datas>
      <observers>
         <custom_module_event_name>
            <type>singleton</type>
            <class>Vendor_Module_Model_Observer</class>
            <method>afterLengowExportDatas</method>
         </custom_module_event_name>
      </observers>
   </lengow_export_products_datas>
</events>
[...]
```

`Observer.php`

```php
[...]
/**
 * @param Varien_Object $observer
 */
public function lengowExportDatas(Varien_Object $observer)
{
   $datas = $observer->getEvent()->getDatas();
   $datas->setData('quantity', 1);
}
[...]
```