### PR TITLE
Fix variable name into checkAndChangeMarketplaceName function

### DIFF
--- a/app/code/community/Lengow/Connector/Model/Import/Order.php
+++ b/app/code/community/Lengow/Connector/Model/Import/Order.php
@@ -966,10 +966,10 @@ class Lengow_Connector_Model_Import_Order extends Mage_Core_Model_Abstract
         if (isset($results->error)) {
             return false;
         }
-        foreach ($results->results as $order) {
-            if ($order->getData('marketplace_lengow') !== (string)$order->marketplace) {
+        foreach ($results->results as $lengowOrder) {
+            if ($order->getData('marketplace_lengow') !== (string)$lengowOrder->marketplace) {
                 try {
-                    $order->setData('marketplace_lengow', (string)$order->marketplace);
+                    $order->setData('marketplace_lengow', (string)$lengowOrder->marketplace);
                     $order->save();
                 } catch (Exception $e) {
                     continue;


### PR DESCRIPTION
Hello,

There is an issue regarding the variable name into checkAndChangeMarketplaceName function: the `foreach` uses an `$order` variable, which has already been defined.
Furthermore, it tries to compare some data with itself.
